### PR TITLE
fix: project export on macOS Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.4] - 2025-12-09
+
+### Fixed
+
+- Fixed project export on macOS Safari - @imaginarny
+
 ## [2.4.3] - 2025-11-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kaplayground",
   "type": "module",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "bin": "scripts/cli.js",
   "scripts": {
     "dev": "vite dev",

--- a/src/util/download.ts
+++ b/src/util/download.ts
@@ -1,10 +1,12 @@
 export const downloadBlob = async (blob: Blob, filename: string) => {
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
+    const reader = new FileReader();
 
-    a.href = url;
-    a.download = filename;
-    a.click();
+    reader.onloadend = () => {
+        const a = document.createElement("a");
+        a.href = reader.result as string;
+        a.download = filename;
+        a.click();
+    };
 
-    URL.revokeObjectURL(url);
+    reader.readAsDataURL(blob);
 };


### PR DESCRIPTION
Possible issue was that blob url is revoked before macOS Safari initiates download with its way of opening a new tab when downloading a file..